### PR TITLE
Avoid queue argument

### DIFF
--- a/rabbitmq_provider/hooks/rabbitmq.py
+++ b/rabbitmq_provider/hooks/rabbitmq.py
@@ -71,11 +71,11 @@ class RabbitMQHook(BaseHook):
         channel.basic_publish(exchange, routing_key, message)
         channel.close()
 
-    def declare_queue(self, name: str, passive: bool = False) -> pika.frame.Method:
+    def declare_queue(self, queue_name: str, passive: bool = False) -> pika.frame.Method:
         """Declare a queue.
 
-        :param name: the queue name
-        :type name: str
+        :param queue_name: the queue name
+        :type queue_name: str
         :param passive: Only check to see if the queue exists and raise
           `ChannelClosed` if it doesn't, defaults to False
         :type passive: bool, optional
@@ -84,45 +84,45 @@ class RabbitMQHook(BaseHook):
         """
         connection = self.get_conn()
         channel = connection.channel()
-        declaration = channel.queue_declare(name, passive)
+        declaration = channel.queue_declare(queue_name, passive)
         channel.close()
         return declaration
 
-    def purge_queue(self, name: str) -> pika.frame.Method:
+    def purge_queue(self, queue_name: str) -> pika.frame.Method:
         """Purge a queue.
 
-        :param name: the queue name
-        :type name: str
+        :param queue_name: the queue name
+        :type queue_name: str
         :returns: Method frame
         :rtype: pika.frame.Method
         """
         connection = self.get_conn()
         channel = connection.channel()
-        return channel.queue_purge(name)
+        return channel.queue_purge(queue_name)
 
-    def delete_queue(self, name: str) -> pika.frame.Method:
+    def delete_queue(self, queue_name: str) -> pika.frame.Method:
         """Delete a queue.
 
-        :param name: the queue name
-        :type name: str
+        :param queue_name: the queue name
+        :type queue_name: str
         :returns: Method frame
         :rtype: pika.frame.Method
         """
         connection = self.get_conn()
         channel = connection.channel()
-        return channel.queue_delete(name)
+        return channel.queue_delete(queue_name)
 
-    def pull(self, queue: str) -> str:
+    def pull(self, queue_name: str) -> str:
         """Pull and acknowledge a message from the queue.
 
-        :param queue: the queue to pull messages from
-        :type queue: str
+        :param queue_name: the queue to pull messages from
+        :type queue_name: str
         :return: the pulled message, if one exists
         :rtype: str
         """
         connection = self.get_conn()
         channel = connection.channel()
-        method_frame, _, body = channel.basic_get(queue)
+        method_frame, _, body = channel.basic_get(queue_name)
         if method_frame:
             channel.basic_ack(method_frame.delivery_tag)
             message = body

--- a/rabbitmq_provider/sensors/rabbitmq.py
+++ b/rabbitmq_provider/sensors/rabbitmq.py
@@ -7,22 +7,22 @@ from rabbitmq_provider.hooks.rabbitmq import RabbitMQHook
 class RabbitMQSensor(BaseSensorOperator):
     """RabbitMQ sensor that monitors a queue for any messages.
 
-    :param rabbit_queue: The name of the queue to monitor
-    :type rabbit_queue: str
+    :param queue_name: The name of the queue to monitor
+    :type queue_name: str
     :param rabbitmq_conn_id: connection that has the RabbitMQ
     connection (i.e amqp://guest:guest@localhost:5672), defaults to "rabbitmq_default"
     :type rabbitmq_conn_id: str, optional
     """
 
-    template_fields = ["rabbit_queue"]
+    template_fields = ["queue_name"]
     ui_color = "#ff6600"
 
     @apply_defaults
     def __init__(
-        self, rabbit_queue: str, rabbitmq_conn_id: str = "rabbitmq_default", **kwargs
+        self, queue_name: str, rabbitmq_conn_id: str = "rabbitmq_default", **kwargs
     ):
         super().__init__(**kwargs)
-        self.rabbit_queue = rabbit_queue
+        self.queue_name = queue_name
         self.rabbitmq_conn_id = rabbitmq_conn_id
 
         self._return_value = None
@@ -34,7 +34,7 @@ class RabbitMQSensor(BaseSensorOperator):
 
     def poke(self, context: dict):
         hook = RabbitMQHook(self.rabbitmq_conn_id)
-        message = hook.pull(self.rabbit_queue)
+        message = hook.pull(self.queue_name)
         if message is not None:
             self._return_value = message
             return True

--- a/rabbitmq_provider/sensors/rabbitmq.py
+++ b/rabbitmq_provider/sensors/rabbitmq.py
@@ -7,22 +7,22 @@ from rabbitmq_provider.hooks.rabbitmq import RabbitMQHook
 class RabbitMQSensor(BaseSensorOperator):
     """RabbitMQ sensor that monitors a queue for any messages.
 
-    :param queue: The name of the queue to monitor
-    :type queue: str
+    :param rabbit_queue: The name of the queue to monitor
+    :type rabbit_queue: str
     :param rabbitmq_conn_id: connection that has the RabbitMQ
     connection (i.e amqp://guest:guest@localhost:5672), defaults to "rabbitmq_default"
     :type rabbitmq_conn_id: str, optional
     """
 
-    template_fields = ["queue"]
+    template_fields = ["rabbit_queue"]
     ui_color = "#ff6600"
 
     @apply_defaults
     def __init__(
-        self, queue: str, rabbitmq_conn_id: str = "rabbitmq_default", **kwargs
+        self, rabbit_queue: str, rabbitmq_conn_id: str = "rabbitmq_default", **kwargs
     ):
         super().__init__(**kwargs)
-        self.queue = queue
+        self.rabbit_queue = rabbit_queue
         self.rabbitmq_conn_id = rabbitmq_conn_id
 
         self._return_value = None
@@ -34,7 +34,7 @@ class RabbitMQSensor(BaseSensorOperator):
 
     def poke(self, context: dict):
         hook = RabbitMQHook(self.rabbitmq_conn_id)
-        message = hook.pull(self.queue)
+        message = hook.pull(self.rabbit_queue)
         if message is not None:
             self._return_value = message
             return True

--- a/tests/sensors/test_sensor.py
+++ b/tests/sensors/test_sensor.py
@@ -17,7 +17,7 @@ def reset_test_queue(monkeypatch):
 
 def test_sensor():
     sensor = RabbitMQSensor(
-        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", rabbit_queue="test"
+        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", queue_name="test"
     )
     hook = RabbitMQHook(rabbitmq_conn_id="conn_rabbitmq")
     hook.publish("", "test", "Hello World")
@@ -30,7 +30,7 @@ def test_sensor():
 
 def test_sensor_with_empty_content():
     sensor = RabbitMQSensor(
-        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", rabbit_queue="test"
+        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", queue_name="test"
     )
     hook = RabbitMQHook(rabbitmq_conn_id="conn_rabbitmq")
     hook.publish("", "test", "")
@@ -45,7 +45,7 @@ def test_sensor_execute_returns_message():
     sensor = RabbitMQSensor(
         task_id="sample_sensor_check",
         rabbitmq_conn_id="conn_rabbitmq",
-        rabbit_queue="test",
+        queue_name="test",
         poke_interval=1,
         timeout=2,
     )

--- a/tests/sensors/test_sensor.py
+++ b/tests/sensors/test_sensor.py
@@ -17,7 +17,7 @@ def reset_test_queue(monkeypatch):
 
 def test_sensor():
     sensor = RabbitMQSensor(
-        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", queue="test"
+        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", rabbit_queue="test"
     )
     hook = RabbitMQHook(rabbitmq_conn_id="conn_rabbitmq")
     hook.publish("", "test", "Hello World")
@@ -30,7 +30,7 @@ def test_sensor():
 
 def test_sensor_with_empty_content():
     sensor = RabbitMQSensor(
-        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", queue="test"
+        task_id="sample_sensor_check", rabbitmq_conn_id="conn_rabbitmq", rabbit_queue="test"
     )
     hook = RabbitMQHook(rabbitmq_conn_id="conn_rabbitmq")
     hook.publish("", "test", "")
@@ -45,7 +45,7 @@ def test_sensor_execute_returns_message():
     sensor = RabbitMQSensor(
         task_id="sample_sensor_check",
         rabbitmq_conn_id="conn_rabbitmq",
-        queue="test",
+        rabbit_queue="test",
         poke_interval=1,
         timeout=2,
     )


### PR DESCRIPTION
When doing local development, the rabbit sensor was just not triggering.
I believe it's because we passed the argument "queue" to the sensor.

In normal, working Airflow, queues often look like this:
![Screenshot from 2021-12-16 15-37-42](https://user-images.githubusercontent.com/31482158/146401764-bbd52493-2705-46ba-a134-22c988cfab01.png)

But in local, it looked like this:
![Screenshot from 2021-12-16 15-39-24](https://user-images.githubusercontent.com/31482158/146401887-0f2a5a2c-bc90-4de9-84a5-47e18d389835.png)
Which looks like we overrode it with our rabbit queue name, instead of the celery queue it's supposed to be.

(Got here by going to admin -> pools -> default_pool)

tes/data#1806

