### PR TITLE
Decode message body

### DIFF
--- a/rabbitmq_provider/hooks/rabbitmq.py
+++ b/rabbitmq_provider/hooks/rabbitmq.py
@@ -125,7 +125,7 @@ class RabbitMQHook(BaseHook):
         method_frame, _, body = channel.basic_get(queue)
         if method_frame:
             channel.basic_ack(method_frame.delivery_tag)
-            message = body
+            message = body.decode()
         else:
             message = None
         channel.close()


### PR DESCRIPTION
Bytes can't be passed to xcom, I was seeing error:
`[2021-12-16 15:24:13,043] {xcom.py:238} ERROR - Could not serialize the XCom value into JSON. If you are using pickles instead of JSON for XCom, then you need to enable pickle support for XCom in your airflow config.`

We wanted to leave it up to the user how to decode, but I think this is best for now

tes/data#1806