### PR TITLE
Reuse connection channel when publishing many messages at once

### DIFF
--- a/rabbitmq_provider/hooks/rabbitmq.py
+++ b/rabbitmq_provider/hooks/rabbitmq.py
@@ -71,6 +71,22 @@ class RabbitMQHook(BaseHook):
         channel.basic_publish(exchange, routing_key, message)
         channel.close()
 
+    def publish_many(self, exchange: str, routing_key: str, messages: list) -> None:
+        """Publish multiple messages with the same connection channel.
+
+        :param exchange: the exchange to publish to
+        :type exchange: str
+        :param routing_key: the routing key to publish to
+        :type routing_key: str
+        :param messages: a list of messages to publish
+        :type messages: list[str]
+        """
+        connection = self.get_conn()
+        channel = connection.channel()
+        for message in messages:
+            channel.basic_publish(exchange, routing_key, message)
+        channel.close()
+
     def declare_queue(self, queue_name: str, passive: bool = False) -> pika.frame.Method:
         """Declare a queue.
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -32,6 +32,16 @@ def test_hook_publish_and_pull(rabbitmq_hook):
     assert message == "Hello World"
 
 
+def test_hook_publish_many_and_pull(rabbitmq_hook):
+    rabbitmq_hook.declare_queue("test")
+    rabbitmq_hook.publish_many("", "test", ["foo","bar","baz"])
+    messages = []
+    messages.append(rabbitmq_hook.pull("test"))
+    messages.append(rabbitmq_hook.pull("test"))
+    messages.append(rabbitmq_hook.pull("test"))
+    assert messages == ["foo","bar","baz"]
+
+
 def test_hook_queue_declare(rabbitmq_hook):
     rabbitmq_hook.declare_queue("test")
     queue = rabbitmq_hook.declare_queue("test", passive=True)
@@ -51,6 +61,6 @@ def test_hook_queue_delete(rabbitmq_hook):
     rabbitmq_hook.delete_queue("to_be_deleted")
     with pytest.raises(
         ChannelClosedByBroker,
-        match="""\(404, "NOT_FOUND - no queue \'to_be_deleted\'""",
+        match="NOT_FOUND - no queue 'to_be_deleted' in vhost '/'",
     ):
         rabbitmq_hook.declare_queue("to_be_deleted", passive=True)

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -61,6 +61,6 @@ def test_hook_queue_delete(rabbitmq_hook):
     rabbitmq_hook.delete_queue("to_be_deleted")
     with pytest.raises(
         ChannelClosedByBroker,
-        match="NOT_FOUND - no queue 'to_be_deleted' in vhost '/'",
+        match="""\(404, "NOT_FOUND - no queue \'to_be_deleted\'""",
     ):
         rabbitmq_hook.declare_queue("to_be_deleted", passive=True)


### PR DESCRIPTION
Add `publish_many(exchange: str, routing_key: str, messages: list)` method to allow publishing multiple messages without the need to open/close a connection for each of them.

Usage:

```python
rabbitmq_hook.publish_many("exchange", "some.routing.key", ["foo","bar","baz"])
```